### PR TITLE
fix getforward for self space in spline.cs

### DIFF
--- a/Assets/SplineTool/Scripts/CorgiSpline/Spline.cs
+++ b/Assets/SplineTool/Scripts/CorgiSpline/Spline.cs
@@ -912,14 +912,9 @@ namespace CorgiSpline
             var vec = (p1.position - p0.position);
             var forward = vec.sqrMagnitude > 0 ? vec.normalized : Vector3.forward;
 
-            if (SplineSpace == Space.Self)
-            {
-                return transform.TransformDirection(forward);
-            }
-            else
-            {
-                return forward;
-            }
+
+            return forward;
+            
         }
 
         /// <summary>


### PR DESCRIPTION
GetForward has redundancy with GetPoint:

GetPoint first transforms local points to world space then GetForward transforms the already world space points again with the same matrix. 

This change removes those redundancies producing consistent results with GetForward in self space.