### PR TITLE
spline editor saves point moves & changes in editor

### DIFF
--- a/Assets/SplineTool/Scripts/CorgiSpline/SplineEditor.cs
+++ b/Assets/SplineTool/Scripts/CorgiSpline/SplineEditor.cs
@@ -1,4 +1,4 @@
-﻿
+
 #if UNITY_EDITOR
 using UnityEngine;
 using UnityEditor;
@@ -226,6 +226,7 @@ namespace CorgiSpline
             if (GUI.changed)
             {
                 serializedObject.ApplyModifiedProperties();
+                EditorUtility.SetDirty(instance);
             }
         }
 
@@ -817,6 +818,7 @@ namespace CorgiSpline
             if (anyMoved || anyRotated || anyScaled)
             {
                 Undo.RegisterCompleteObjectUndo(instance, "Move Point");
+                EditorUtility.SetDirty(instance);
 
                 var original_point = instance.Points[point_index];
                 instance.Points[point_index] = splinePoint;


### PR DESCRIPTION
in order to serialize changes must use EditorUtility.SetDirty(instance) -- otherwise changes get lost when going from editor to play mode. 

https://forum.unity.com/threads/custom-editor-losing-settings-on-play.130889/#post-2618242

This pull request isn't comprehensive for changes needed to fix this script but fixes points moving and changes in the gui